### PR TITLE
xrEngine Startup enumerates sound devices before config evaluation

### DIFF
--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -161,6 +161,7 @@ void CheckPrivilegySlowdown()
 
 ENGINE_API void Startup()
 {
+    ISoundManager::enumerate_devices();
     execUserScript();
     InitSound();
 
@@ -216,7 +217,6 @@ ENGINE_API int RunApplication()
             MessageBox(nullptr, "The game has already been launched!", nullptr, MB_ICONERROR | MB_OK);
             return 2;
         }
-        
     }
 #endif
     *g_sLaunchOnExit_app = 0;

--- a/src/xrSound/Sound.h
+++ b/src/xrSound/Sound.h
@@ -165,6 +165,8 @@ public:
     static void _create();
     static void _destroy();
 
+    static void enumerate_devices();
+
     virtual void _restart() = 0;
     virtual bool i_locked() = 0;
 

--- a/src/xrSound/SoundRender_CoreA.cpp
+++ b/src/xrSound/SoundRender_CoreA.cpp
@@ -6,10 +6,11 @@
 
 CSoundRender_CoreA* SoundRenderA = nullptr;
 
-CSoundRender_CoreA::CSoundRender_CoreA() : CSoundRender_Core()
+CSoundRender_CoreA::CSoundRender_CoreA(ALDeviceList* deviceList) : CSoundRender_Core()
 {
+    pDeviceList = deviceList;
+
     pDevice = nullptr;
-    pDeviceList = nullptr;
     pContext = nullptr;
     eaxSet = nullptr;
     eaxGet = nullptr;
@@ -71,18 +72,15 @@ bool CSoundRender_CoreA::EAXTestSupport(bool isDeferred)
 void CSoundRender_CoreA::_restart() { inherited::_restart(); }
 void CSoundRender_CoreA::_initialize()
 {
-    pDeviceList = new ALDeviceList();
-
     if (0 == pDeviceList->GetNumDevices())
     {
         CHECK_OR_EXIT(0, 
             "OpenAL: Can't create sound device.\n"
-            "Òû óñòàíîâèë OpenAL?\n"
-            "Óñòàíîâùèê íàõîäèòñÿ â /soft/oalinst.exe\n"
+            "Ã’Ã» Ã³Ã±Ã²Ã Ã­Ã®Ã¢Ã¨Ã« OpenAL?\n"
+            "Ã“Ã±Ã²Ã Ã­Ã®Ã¢Ã¹Ã¨Ãª Ã­Ã ÃµÃ®Ã¤Ã¨Ã²Ã±Ã¿ Ã¢ /soft/oalinst.exe\n"
             "Have you got OpenAL installed?\n"
             "The installer is located in /soft/oalinst.exe"
         );
-        xr_delete(pDeviceList);
     }
     pDeviceList->SelectBestDevice();
     R_ASSERT(snd_device_id >= 0 && snd_device_id < pDeviceList->GetNumDevices());
@@ -193,7 +191,6 @@ void CSoundRender_CoreA::_clear()
     pContext = nullptr;
     alcCloseDevice(pDevice);
     pDevice = nullptr;
-    xr_delete(pDeviceList);
 }
 
 void CSoundRender_CoreA::i_eax_set(const GUID* guid, u32 prop, void* val, u32 sz) { eaxSet(guid, prop, 0, val, sz); }

--- a/src/xrSound/SoundRender_CoreA.h
+++ b/src/xrSound/SoundRender_CoreA.h
@@ -56,7 +56,7 @@ protected:
     void update_listener(const Fvector& P, const Fvector& D, const Fvector& N, float dt) override;
 
 public:
-    CSoundRender_CoreA();
+    CSoundRender_CoreA(ALDeviceList* deviceList);
     virtual ~CSoundRender_CoreA();
 
     void _initialize() override;

--- a/src/xrSound/sound.cpp
+++ b/src/xrSound/sound.cpp
@@ -5,9 +5,13 @@
 XRSOUND_API xr_token* snd_devices_token = nullptr;
 XRSOUND_API u32 snd_device_id = u32(-1);
 
+ALDeviceList* deviceList = nullptr;
+
 void ISoundManager::_create()
 {
-    SoundRenderA = new CSoundRender_CoreA();
+    if (deviceList == nullptr)
+        enumerate_devices();
+    SoundRenderA = new CSoundRender_CoreA(deviceList);
     SoundRender = SoundRenderA;
     GEnv.Sound = SoundRender;
     SoundRender->bPresent = strstr(Core.Params, "-nosound") == nullptr;
@@ -21,4 +25,10 @@ void ISoundManager::_destroy()
     GEnv.Sound->_clear();
     xr_delete(SoundRender);
     GEnv.Sound = nullptr;
+    xr_delete(deviceList);
+}
+
+void ISoundManager::enumerate_devices()
+{
+    deviceList = new ALDeviceList();
 }


### PR DESCRIPTION
Fixes issue where CoC would not respect the snd_device config parameter when selecting an OpenAL device. snd_device console command was being evaluated before the sound manager produced the device name to device id token mapping, causing snd_device to evaluate as if it had not been set in the user's config to begin with. This change ensures the device name to device id token mapping is populated before snd_device is evaluated.